### PR TITLE
fix input

### DIFF
--- a/macros/utils/compile_aggfunc.sql
+++ b/macros/utils/compile_aggfunc.sql
@@ -22,7 +22,7 @@ split_part(
 {%- elif aggfunc == 'notnull' -%}
 max({{alias_col}} is not null)
 {%- elif aggfunc == 'listagg' -%}
-{{ thesis_dbt.aggfunc_listagg(alias_col, ', ') }}
+{{ thesis_dbt.aggfunc_listagg(alias_col) }}
 {%- else -%}
 {{aggfunc}}({{alias_col}})
 {%- endif -%}


### PR DESCRIPTION
This PR:
* fixes `listagg` aggregation functionality by removing an unnecessary argument when calling the `aggfunc_listagg` macro from within the `compile_aggfunc` macro