### PR TITLE
Hotfix parse attribute

### DIFF
--- a/macros/model_builds/build_dataset.sql
+++ b/macros/model_builds/build_dataset.sql
@@ -147,10 +147,10 @@ with {{sql_graph['primary_event_cte']}} as (
     select
         {% for sc in standard_columns -%}
         {%- if not loop.first -%}, {% endif -%}{{sc}} as {{secondary_event}}_{{sc}}
-        {% endfor %}
+        {% endfor -%}
         {%- for j in se['joins'].keys() -%}
         {%- set join_reqs = se['joins'][j] -%}
-        {%- for sm in join_reqs['metrics'] -%}
+        {% for sm in join_reqs['metrics'] -%}
         , {{sm['parsed_attribute']}} as {{sm['metric_name']}}
         {%- endfor -%}
         {% endfor %}

--- a/macros/utils/parse_attribute.sql
+++ b/macros/utils/parse_attribute.sql
@@ -19,9 +19,9 @@
     {%- set coalesce_suffix = ', '~backup_value~')' -%}
 {%- endif -%}
 {%- if attribute_name in ['event_id', 'event_at', var('customer_id')] -%}
-{{coalesce_prefix}}{{attribute_name}}{{coalesce_suffix}}{{condition_str}}
+{{coalesce_prefix}}{{attribute_name}}{{condition_str}}{{coalesce_suffix}}
 {%- else -%}
-{{coalesce_prefix}}nullif(json_extract_path_text(attributes, '{{attribute_name}}'), ''){{coalesce_suffix}}{{condition_str}}
+{{coalesce_prefix}}nullif(json_extract_path_text(attributes, '{{attribute_name}}'), ''){{condition_str}}{{coalesce_suffix}}
 {%- endif -%}
 {%- endmacro -%}
 
@@ -42,8 +42,8 @@
     {%- set coalesce_suffix = ', '~backup_value~')' -%}
 {%- endif -%}
 {%- if attribute_name in ['event_id', 'event_at', var('customer_id')] -%}
-{{coalesce_prefix}}{{attribute_name}}{{coalesce_suffix}}{{condition_str}}
+{{coalesce_prefix}}{{attribute_name}}{{condition_str}}{{coalesce_suffix}}
 {%- else -%}
-{{coalesce_prefix}}nullif(to_varchar(get_path(attributes, '{{attribute_name}}')), ''){{coalesce_suffix}}{{condition_str}}
+{{coalesce_prefix}}nullif(to_varchar(get_path(attributes, '{{attribute_name}}')), ''){{condition_str}}{{coalesce_suffix}}
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
This PR:
* cleans up excess whitespace rendered by the `build_dataset` macro
* reorders the `condition` and `backup` parameters in the `parse_attribute` macro