### PR TITLE
update customer id references

### DIFF
--- a/macros/model_builds/build_event.sql
+++ b/macros/model_builds/build_event.sql
@@ -10,11 +10,12 @@ build_event: Compiles a final select statement in a standardized format so that 
 {% endmacro %}
 
 
-{% macro default__build_event(cte, attributes=none, event_at_column="event_at") %}
+{% macro default__build_event(cte, attributes=none, event_at_column="event_at", event_stream=none) %}
+{%- set customer_id = var('customer_id', var('thesis_dbt')[event_stream]['customer_id']) -%}
 
 select
-    {{ thesis_dbt.surrogate_key([var('customer_id'), event_at_column, "'"~this.name~"'"]) }} as event_id
-    , {{ var('customer_id') }} as {{ var('customer_id') }}
+    {{ thesis_dbt.surrogate_key([customer_id, event_at_column, "'"~this.name~"'"]) }} as event_id
+    , {{ customer_id }} as {{ customer_id }}
     , '{{ this.name }}' as event_name
     , {{event_at_column}} as event_at
     , {{ thesis_dbt.attributes_to_json(attributes) }} as attributes

--- a/macros/model_builds/build_metric.sql
+++ b/macros/model_builds/build_metric.sql
@@ -3,6 +3,7 @@
 {% endmacro %}
 
 {% macro default__build_metric(event_stream) %}
+{%- do config.update({'event_stream': event_stream}) -%}
 {%- set is_metric = config.require('is_metric') -%}
 {%- set event_name = config.require('event_name') -%}
 {%- set attribute = config.require('attribute') -%}

--- a/macros/utils/parse_attribute.sql
+++ b/macros/utils/parse_attribute.sql
@@ -3,6 +3,8 @@
 {%- endmacro -%}
 
 {%- macro default__parse_attribute(metric_node) -%}
+{%- set event_stream = metric_node.config.get('event_stream') -%}
+{%- set customer_id = var('customer_id', var('thesis_dbt')[event_stream]['customer_id']) -%}
 {%- set attribute_name = metric_node.config.get('attribute') -%}
 {%- set condition = metric_node.config.get('condition', none) -%}
 {%- if condition is none -%}
@@ -18,7 +20,7 @@
     {%- set coalesce_prefix = 'coalesce(' -%}
     {%- set coalesce_suffix = ', '~backup_value~')' -%}
 {%- endif -%}
-{%- if attribute_name in ['event_id', 'event_at', var('customer_id')] -%}
+{%- if attribute_name in ['event_id', 'event_at', customer_id] -%}
 {{coalesce_prefix}}{{attribute_name}}{{condition_str}}{{coalesce_suffix}}
 {%- else -%}
 {{coalesce_prefix}}nullif(json_extract_path_text(attributes, '{{attribute_name}}'), ''){{condition_str}}{{coalesce_suffix}}
@@ -26,6 +28,8 @@
 {%- endmacro -%}
 
 {%- macro snowflake__parse_attribute(metric_node) -%}
+{%- set event_stream = metric_node.config.get('event_stream') -%}
+{%- set customer_id = var('customer_id', var('thesis_dbt')[event_stream]['customer_id']) -%}
 {%- set attribute_name = metric_node.config.get('attribute') -%}
 {%- set condition = metric_node.config.get('condition', none) -%}
 {%- if condition is none -%}
@@ -41,7 +45,7 @@
     {%- set coalesce_prefix = 'coalesce(' -%}
     {%- set coalesce_suffix = ', '~backup_value~')' -%}
 {%- endif -%}
-{%- if attribute_name in ['event_id', 'event_at', var('customer_id')] -%}
+{%- if attribute_name in ['event_id', 'event_at', customer_id] -%}
 {{coalesce_prefix}}{{attribute_name}}{{condition_str}}{{coalesce_suffix}}
 {%- else -%}
 {{coalesce_prefix}}nullif(to_varchar(get_path(attributes, '{{attribute_name}}')), ''){{condition_str}}{{coalesce_suffix}}


### PR DESCRIPTION
Resolves #43 

This PR:
* adds functionality to accept an alternate method of passing the `customer_id` alias to an event stream model

Example (in `dbt_project.yml`):
```
vars:
  project_name:
    thesis_dbt:
      event_stream_name:
        customer_id: customer_id_alias
```